### PR TITLE
Use unified diffs for omni.ja changes

### DIFF
--- a/certsuite/omni_analyzer.py
+++ b/certsuite/omni_analyzer.py
@@ -79,7 +79,7 @@ class OmniAnalyzer(object):
             self.getomni(workdir)
             unzip_omnifile(self.reference_omni_ja, os.path.join(workdir, 'reference'))
 
-            cmd = ['diff', '--new-file', os.path.join(workdir, 'reference'), os.path.join(workdir, 'device')]
+            cmd = ['diff', 'u', '--new-file', os.path.join(workdir, 'reference'), os.path.join(workdir, 'device')]
             try:
                 diff = subprocess.check_output(cmd)
             except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Unified diffs are more commonly used these days and aid reading of the changes.
